### PR TITLE
Lab 02: Logan Dooley

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,15 @@
-# lab02-debugging
-
-# Setup 
-
-Create a [Shadertoy account](https://www.shadertoy.com/). Either fork this shadertoy, or create a new shadertoy and copy the code from the [Debugging Puzzle](https://www.shadertoy.com/view/flGfRc).
-
-Let's practice debugging! We have a broken shader. It should produce output that looks like this:
-[Unbelievably beautiful shader](https://user-images.githubusercontent.com/1758825/200729570-8e10a37a-345d-4aff-8eff-6baf54a32a40.webm)
-
-It don't do that. Correct THREE of the FIVE bugs that are messing up the output. You are STRONGLY ENCOURAGED to work with a partner and pair program to force you to talk about your debugging thought process out loud.
-
-Extra credit if you can find all FIVE bugs.
-
 # Submission
-- Create a pull request to this repository
-- In the README, include the names of both your team members
-- In the README, create a link to your shader toy solution with the bugs corrected
-- In the README, describe each bug you found and include a sentence about HOW you found it.
-- Make sure all three of your shadertoys are set to UNLISTED or PUBLIC (so we can see them!)
+Worked with Rebecca Waterson
+
+https://www.shadertoy.com/view/tfsfWf
+
+line 97: Compilation error using vec instead of vec2
+- Found through compiler error
+line 101: Raycast used uv instead of uv2
+- Found by rendering just uvs as color and noticing they were shifted
+line 11: Aspect ratio transform was using x/x instead of x/y
+- Found by rendering ray directions
+line 18: Iteration count was too low to see much ground
+- Found by noticing effects around edges of spheres, which I knew that when ray marching could be caused by approaching tangent surfaces.
+line 75: Made sure to reflect dir instead of eye about the normal
+- Found by rendering the reflected direction as color

--- a/README.md
+++ b/README.md
@@ -3,13 +3,8 @@ Worked with Rebecca Waterson
 
 https://www.shadertoy.com/view/tfsfWf
 
-line 97: Compilation error using vec instead of vec2
-- Found through compiler error
-line 101: Raycast used uv instead of uv2
-- Found by rendering just uvs as color and noticing they were shifted
-line 11: Aspect ratio transform was using x/x instead of x/y
-- Found by rendering ray directions
-line 18: Iteration count was too low to see much ground
-- Found by noticing effects around edges of spheres, which I knew that when ray marching could be caused by approaching tangent surfaces.
-line 75: Made sure to reflect dir instead of eye about the normal
-- Found by rendering the reflected direction as color
+- line 97: Compilation error using vec instead of vec2. Found through compiler error
+- line 101: Raycast used uv instead of uv2. Found by rendering just uvs as color and noticing they were shifted
+- line 11: Aspect ratio transform was using x/x instead of x/y. Found by rendering ray directions
+- line 18: Iteration count was too low to see much ground. Found by noticing effects around edges of spheres, which I knew that when ray marching could be caused by approaching tangent surfaces.
+- line 75: Made sure to reflect dir instead of eye about the normal. Found by rendering the reflected direction as color


### PR DESCRIPTION
Worked with Rebecca Waterson

https://www.shadertoy.com/view/tfsfWf

- line 97: Compilation error using vec instead of vec2. Found through compiler error
- line 101: Raycast used uv instead of uv2. Found by rendering just uvs as color and noticing they were shifted
- line 11: Aspect ratio transform was using x/x instead of x/y. Found by rendering ray directions
- line 18: Iteration count was too low to see much ground. Found by noticing effects around edges of spheres, which I knew that when ray marching could be caused by approaching tangent surfaces.
- line 75: Made sure to reflect dir instead of eye about the normal. Found by rendering the reflected direction as color